### PR TITLE
Disambiguate windows command used to find a given binary.

### DIFF
--- a/src/filesystem/Filesystem.php
+++ b/src/filesystem/Filesystem.php
@@ -918,10 +918,10 @@ final class Filesystem {
    */
   public static function resolveBinary($binary) {
     if (phutil_is_windows()) {
-      list($err, $stdout) = exec_manual('where %s', $binary);
+      list($err, $stdout) = exec_manual('where.exe %s', $binary); // .exe avoids failure when 'where' is an alias to 'Where-Object'
       $stdout = phutil_split_lines($stdout);
 
-      // If `where %s` could not find anything, check for relative binary
+      // If `where.exe %s` could not find anything, check for relative binary
       if ($err) {
         $path = self::resolvePath($binary);
         if (self::pathExists($path)) {


### PR DESCRIPTION
Testing:
1. See the problem:
   
   > arc unit
   > …
   > Unable to find msbuild or xbuild in PATH!
   > …
   > where msbuild
   > C:\Windows\System32\where.exe  msbuild
   > C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe
   > where
   > cmdlet Where-Object at command pipeline position 1
   > …
   > Remove-Item alias:where
   > Remove-Item : Alias was not removed because alias where is constant or read-only.
   > …
2. Apply this change
3. `arc unit` no longer barfs with “Unable to find msbuild or xbuild in PATH!”
